### PR TITLE
Mac build fixes

### DIFF
--- a/Assets/Editor/CopyLayouts.cs
+++ b/Assets/Editor/CopyLayouts.cs
@@ -4,6 +4,7 @@ using UnityEditor;
 using System.IO;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
+using UnityEngine;
 
 public class CopyLayouts : IPostprocessBuildWithReport
 {
@@ -11,13 +12,54 @@ public class CopyLayouts : IPostprocessBuildWithReport
 
     public void OnPostprocessBuild(BuildReport report)
     {
-        var out_path = Path.GetDirectoryName(report.summary.outputPath);
-        var layout_path = out_path + "/MapNuke_Data/Layouts";
-        Directory.CreateDirectory(layout_path);
+        if (report.summary.platform == BuildTarget.StandaloneOSX)
+        {
+            Debug.Log("This is a standalone macos build");
+            MacosFetchNations(report);
+            MacosFetchLayout(report);
+        }
+        else
+        {
+            Debug.Log("This is a standalone linux/windows build");
+            FetchLayout(report);
+        }
+    }
+
+    private static void FetchLayout(BuildReport report)
+    {
+        var outPath = Path.GetDirectoryName(report.summary.outputPath);
+        var layoutPath = $"{outPath}/MapNuke_Data/Layouts";
+        Directory.CreateDirectory(layoutPath);
         foreach (var s in Directory.GetFiles("Assets/Layouts", "*.xml"))
         {
             if (s.EndsWith(".meta")) continue;
-            File.Copy(s, layout_path + '/' + Path.GetFileName(s));
+            File.Copy(s, $"{layoutPath}/{Path.GetFileName(s)}");
+        }
+    }
+
+
+    // These two methods exist because there does not seem to be an easy way to pull files specifically into the .app 
+    private static void MacosFetchNations(BuildReport report)
+    {
+        var outPath = Path.GetDirectoryName(report.summary.outputPath);
+        var layoutPath = $"{outPath}/MapNuke.app/Contents/Nations";
+        Directory.CreateDirectory(layoutPath);
+        foreach (var s in Directory.GetFiles("Assets/Nations", "*.xml"))
+        {
+            if (s.EndsWith(".meta")) continue;
+            File.Copy(s, $"{layoutPath}/{Path.GetFileName(s)}");
+        }
+    }
+
+    private static void MacosFetchLayout(BuildReport report)
+    {
+        var outPath = Path.GetDirectoryName(report.summary.outputPath);
+        var layoutPath = $"{outPath}/MapNuke.app/Contents/Layouts";
+        Directory.CreateDirectory(layoutPath);
+        foreach (var s in Directory.GetFiles("Assets/Layouts", "*.xml"))
+        {
+            if (s.EndsWith(".meta")) continue;
+            File.Copy(s, $"{layoutPath}/{Path.GetFileName(s)}");
         }
     }
 }

--- a/Assets/Editor/CopyLayouts.cs
+++ b/Assets/Editor/CopyLayouts.cs
@@ -15,8 +15,8 @@ public class CopyLayouts : IPostprocessBuildWithReport
         if (report.summary.platform == BuildTarget.StandaloneOSX)
         {
             Debug.Log("This is a standalone macos build");
-            MacosFetchNations(report);
-            MacosFetchLayout(report);
+            MacosPackageAssets(report, "Layouts");
+            MacosPackageAssets(report, "Nations");
         }
         else
         {
@@ -38,28 +38,16 @@ public class CopyLayouts : IPostprocessBuildWithReport
     }
 
 
-    // These two methods exist because there does not seem to be an easy way to pull files specifically into the .app 
-    private static void MacosFetchNations(BuildReport report)
+    // This logic fork exist because there does not seem to be an easy way to pull files specifically into the .app 
+    private static void MacosPackageAssets(BuildReport report, string asset)
     {
         var outPath = Path.GetDirectoryName(report.summary.outputPath);
-        var layoutPath = $"{outPath}/MapNuke.app/Contents/Nations";
-        Directory.CreateDirectory(layoutPath);
-        foreach (var s in Directory.GetFiles("Assets/Nations", "*.xml"))
+        var assetPath = $"{outPath}/MapNuke.app/Contents/{asset}";
+        Directory.CreateDirectory(assetPath);
+        foreach (var s in Directory.GetFiles($"Assets/{asset}", "*.xml"))
         {
             if (s.EndsWith(".meta")) continue;
-            File.Copy(s, $"{layoutPath}/{Path.GetFileName(s)}");
-        }
-    }
-
-    private static void MacosFetchLayout(BuildReport report)
-    {
-        var outPath = Path.GetDirectoryName(report.summary.outputPath);
-        var layoutPath = $"{outPath}/MapNuke.app/Contents/Layouts";
-        Directory.CreateDirectory(layoutPath);
-        foreach (var s in Directory.GetFiles("Assets/Layouts", "*.xml"))
-        {
-            if (s.EndsWith(".meta")) continue;
-            File.Copy(s, $"{layoutPath}/{Path.GetFileName(s)}");
+            File.Copy(s, $"{assetPath}/{Path.GetFileName(s)}");
         }
     }
 }


### PR DESCRIPTION
Issue: macos builds are busted because the Layouts and Nations folders are not packaged within the .app folder during build.

Solution: forked build step for specifically macos to enable these assets to be packaged the way they are expected to be by the application.

Caveats: I could not find an easy way to fetch the build folder name, this has lead to it being hard coded in the fix, if there is a way to do this easily would be happy to add it but didnt see it anywhere in the docs which seems weird.